### PR TITLE
Pest fixes, and avoid passphrase prompt when possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ Cargo.lock
 !.vscode/launch.json
 !.vscode/extensions.json
 
+### clion/jetbrains ide
+.idea
+
 ### VisualStudioCode Patch ###
 # Ignore all local history of files
 .history

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git2_credentials"
-version = "0.7.4-dev"
+version = "0.7.4-patch"
 authors = ["David Bernard <david.bernard.31@gmail.com>"]
 edition = "2018"
 description = "Provide credential function to used with git2::RemoteCallbacks.credentials"
@@ -12,12 +12,14 @@ homepage = "https://github.com/davidB/git2_credentials"
 exclude = ["/.github", ".dependabot/", "/docs/**", "/scripts", ".gitignore", "/tests/**"]
 
 [dependencies]
+base64 = "0.13"
 dirs = "^3.0"
 git2 = { version = "^0.13", default-features = false }
 dialoguer = { version = "^0.8", optional = true }
 pest = "^2.1"
 pest_derive = "^2.1"
 regex = "^1.4"
+log = "0.4"
 
 [dev-dependencies]
 pretty_assertions = "0.7.1"

--- a/src/ssh_config.pest
+++ b/src/ssh_config.pest
@@ -1,7 +1,8 @@
-config = _{ SOI ~ (newline | kv)* ~ host* ~ EOI }
-host = { ^"Host" ~ pattern+ ~ option* ~ newline* }
+config = _{ SOI ~ ( newline | kv | in_comment )* ~ host* ~ ( newline | in_comment )* ~ EOI }
+host = { ^"Host" ~ pattern+ ~ ( option | host_comment )* ~ newline ~ ( newline | in_comment )* }
 kv = { key ~ value }
 option = { newline ~ kv}
+host_comment = { newline ~ in_comment }
 key = @{ !^"Host" ~ ('a'..'z' | 'A'..'Z' | ASCII_DIGIT)+ }
 value = ${ value_unquoted | value_quoted }
 value_unquoted = { (!newline ~ !dquote ~ ANY)+ }
@@ -14,4 +15,4 @@ dquote = _{ "\"" }
 newline = _{ "\n" | "\r\n" }
 
 WHITESPACE = _{ " " | "\t" }
-COMMENT = _{ "#" ~ (!newline ~ ANY)* }
+in_comment = { "#" ~ (!newline ~ ANY)* }

--- a/src/ui4dialoguer.rs
+++ b/src/ui4dialoguer.rs
@@ -1,5 +1,4 @@
-use dialoguer::Input;
-use dialoguer::Password;
+use dialoguer::{Input, Password};
 use std::error::Error;
 
 pub struct CredentialUI4Dialoguer;


### PR DESCRIPTION
- pest fixes: support comments inside Host section and after hosts
- use case-insensitive match on option keys ("IdentityFile", "identityfile", etc.)
- avoid prompting for passphrase: if ssh key is unencrypted, no passphrase is needed. if encrypted, use ssh-agent so user is only prompted once instead of each iteration
- bump version to 0.7.4-patch

