### PR TITLE
Re-exporting `git2` crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@
 #[macro_use]
 extern crate pest_derive;
 
+pub use git2;
+
 mod ssh_config;
 
 #[cfg(feature = "ui4dialoguer")]


### PR DESCRIPTION
Fixes #41